### PR TITLE
Allow customizing keyword trigger

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,5 +7,12 @@
     "options": {
         "query_debounce": 0.1
     },
-    "preferences": []
+    "preferences": [
+        {
+            "id": "kw",
+            "type": "keyword",
+            "name": "Brotab",
+            "default_value": "brotab"
+        }
+    ]
 }


### PR DESCRIPTION
@brpaz Thank you so much for this extension and for putting it together so quickly! It helps me work with my tab mess without too much thinking.

For some reason, the default `brotab` keyword trigger was not working for me as advertised. I've tried to introduce an explicit preference and now it works like a charm, with both the default and customized keyword.