### PR TITLE
Python < 3.7 support

### DIFF
--- a/brotab/client.py
+++ b/brotab/client.py
@@ -34,7 +34,7 @@ class BrotabClient:
         """ Index the clients connected """
         self.clients = {}
 
-        result = subprocess.run(['brotab', 'clients'], capture_output=True, check=True)
+        result = subprocess.run(['brotab', 'clients'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
         output_text = result.stdout.decode("utf-8")
         for line in output_text.splitlines():
@@ -46,7 +46,7 @@ class BrotabClient:
 
         self.tabs = []
 
-        result = subprocess.run(['brotab', 'list'], capture_output=True, check=True)
+        result = subprocess.run(['brotab', 'list'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
 
         output_text = result.stdout.decode("utf-8")
         if not output_text.strip():


### PR DESCRIPTION
The `capture_output` parameter in `subprocess.run` was introduced in Python 3.7 and the plugin was crashing on my system, so I've replaced it with `stdout=PIPE` and `stderr=PIPE` (these parameters values do the same behaviour as far as I understand) and now the plugin works if a user has Python < 3.7 (tested on Python 3.6)